### PR TITLE
Input validation for flashloan

### DIFF
--- a/aave-core/sources/aave-logic/validation_logic.move
+++ b/aave-core/sources/aave-logic/validation_logic.move
@@ -32,6 +32,11 @@ module aave_pool::validation_logic {
             vector::length(assets) > 0,
             error_config::get_einconsistent_flashloan_params()
         );
+        // ensure that the number of assets is less than the maximum allowed reserves
+        assert!(
+            vector::length(assets) < (reserve_config::get_max_reserves_count() as u64),
+            error_config::get_einconsistent_flashloan_params()
+        );
         // ensure arguments consistency
         assert!(
             vector::length(assets) == vector::length(amounts)

--- a/aave-core/sources/aave-logic/validation_logic.move
+++ b/aave-core/sources/aave-logic/validation_logic.move
@@ -45,7 +45,7 @@ module aave_pool::validation_logic {
             error_config::get_einconsistent_flashloan_params()
         );
 
-        // Use SimpleMap for O(n) uniqueness validation instead of O(n²) nested loops
+        // Use SimpleMap for O(n) uniqueness validation instead of O(n^2) nested loops
         let seen_assets = simple_map::new<address, bool>();
         for (i in 0..vector::length(assets)) {
             let asset = *vector::borrow(assets, i);

--- a/aave-core/sources/aave-logic/validation_logic.move
+++ b/aave-core/sources/aave-logic/validation_logic.move
@@ -70,6 +70,8 @@ module aave_pool::validation_logic {
     public fun validate_flashloan_simple(
         reserve_data: Object<ReserveData>, amount: u256
     ) {
+        assert!(amount != 0, error_config::get_einvalid_amount());
+
         let reserve_configuration =
             pool::get_reserve_configuration_by_reserve_data(reserve_data);
         let (is_active, _, _, is_paused) =

--- a/aave-core/tests/aave-logic/flashloan_validation_tests.move
+++ b/aave-core/tests/aave-logic/flashloan_validation_tests.move
@@ -791,6 +791,51 @@ module aave_pool::flashloan_validation_tests {
             usre1 = @0x41
         )
     ]
+    // validate_flashloan() with assets are empty (revert expected)
+    #[expected_failure(abort_code = 49, location = aave_pool::validation_logic)]
+    fun test_validate_flashloan_with_assets_are_empty(
+        aave_pool: &signer,
+        aave_role_super_admin: &signer,
+        aave_std: &signer,
+        underlying_tokens_admin: &signer,
+        usre1: &signer
+    ) {
+        let user1_address = signer::address_of(usre1);
+
+        init_reserves(
+            aave_pool,
+            aave_role_super_admin,
+            aave_std,
+            underlying_tokens_admin
+        );
+
+        // user1 flashloan 1000 u_1 token from the pool
+        let assets = vector[];
+        let amounts = vector[];
+        let interest_rate_modes = vector[];
+        let flashloan_receipts =
+            flashloan_logic::flash_loan(
+                usre1,
+                user1_address,
+                assets,
+                amounts,
+                interest_rate_modes,
+                user1_address,
+                0
+            );
+
+        flashloan_logic::pay_flash_loan_complex(usre1, flashloan_receipts);
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_role_super_admin = @aave_acl,
+            aave_std = @std,
+            underlying_tokens_admin = @aave_mock_underlyings,
+            usre1 = @0x41
+        )
+    ]
     // validate_flashloan() with The number of assets exceeds the maximum limit
     #[expected_failure(abort_code = 49, location = aave_pool::validation_logic)]
     fun test_validate_flashloan_with_assets_exceeds_maximum_limit(

--- a/aave-core/tests/aave-logic/flashloan_validation_tests.move
+++ b/aave-core/tests/aave-logic/flashloan_validation_tests.move
@@ -324,9 +324,27 @@ module aave_pool::flashloan_validation_tests {
         let underlying_u1_token_address =
             mock_underlying_token_factory::token_address(utf8(b"U_1"));
 
+        // mint 1000000000 u_1 token to user1
+        mock_underlying_token_factory::mint(
+            underlying_tokens_admin,
+            user1_address,
+            (convert_to_currency_decimals(underlying_u1_token_address, 1000000000) as u64),
+            underlying_u1_token_address
+        );
+
+        let supplied_amount =
+            convert_to_currency_decimals(underlying_u1_token_address, 1000);
+        supply_logic::supply(
+            usre1,
+            underlying_u1_token_address,
+            supplied_amount,
+            user1_address,
+            0
+        );
+
         // user1 flashloan 1000 u_1 token from the pool
         let assets = vector[underlying_u1_token_address, underlying_u1_token_address];
-        let amounts = vector[1000, 222];
+        let amounts = vector[100, 200];
         let flashloan_receipts =
             flashloan_logic::flash_loan(
                 usre1,

--- a/aave-core/tests/aave-logic/flashloan_validation_tests.move
+++ b/aave-core/tests/aave-logic/flashloan_validation_tests.move
@@ -3,6 +3,7 @@ module aave_pool::flashloan_validation_tests {
 
     use std::signer;
     use std::string::utf8;
+    use std::vector;
     use aave_config::reserve_config;
     use aave_pool::supply_logic;
     use aave_pool::flashloan_logic;
@@ -779,5 +780,59 @@ module aave_pool::flashloan_validation_tests {
 
         // ----> flashloan user repays flashloan + premium
         flashloan_logic::pay_flash_loan_simple(usre1, flashloan_receipt);
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_role_super_admin = @aave_acl,
+            aave_std = @std,
+            underlying_tokens_admin = @aave_mock_underlyings,
+            usre1 = @0x41
+        )
+    ]
+    // validate_flashloan() with The number of assets exceeds the maximum limit
+    #[expected_failure(abort_code = 49, location = aave_pool::validation_logic)]
+    fun test_validate_flashloan_with_assets_exceeds_maximum_limit(
+        aave_pool: &signer,
+        aave_role_super_admin: &signer,
+        aave_std: &signer,
+        underlying_tokens_admin: &signer,
+        usre1: &signer
+    ) {
+        let user1_address = signer::address_of(usre1);
+
+        init_reserves(
+            aave_pool,
+            aave_role_super_admin,
+            aave_std,
+            underlying_tokens_admin
+        );
+
+        let underlying_u1_token_address =
+            mock_underlying_token_factory::token_address(utf8(b"U_1"));
+
+        // user1 flashloan 1000 u_1 token from the pool
+        let assets = vector[underlying_u1_token_address];
+        let amounts = vector[1000];
+        let interest_rate_modes = vector[2];
+        for (i in 0..reserve_config::get_max_reserves_count()) {
+            vector::push_back(&mut assets, underlying_u1_token_address);
+            vector::push_back(&mut amounts, 1000);
+            vector::push_back(&mut interest_rate_modes, 2);
+        };
+
+        let flashloan_receipts =
+            flashloan_logic::flash_loan(
+                usre1,
+                user1_address,
+                assets,
+                amounts,
+                vector[0, 2],
+                user1_address,
+                0
+            );
+
+        flashloan_logic::pay_flash_loan_complex(usre1, flashloan_receipts);
     }
 }

--- a/aave-core/tests/aave-logic/flashloan_validation_tests.move
+++ b/aave-core/tests/aave-logic/flashloan_validation_tests.move
@@ -946,4 +946,46 @@ module aave_pool::flashloan_validation_tests {
 
         flashloan_logic::pay_flash_loan_complex(usre1, flashloan_receipts);
     }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_role_super_admin = @aave_acl,
+            aave_std = @std,
+            underlying_tokens_admin = @aave_mock_underlyings,
+            usre1 = @0x41
+        )
+    ]
+    // validate_flashloan_simple() with amount is zero (revert expected)
+    #[expected_failure(abort_code = 26, location = aave_pool::validation_logic)]
+    fun test_validate_flashloan_simple_with_amount_is_zero(
+        aave_pool: &signer,
+        aave_role_super_admin: &signer,
+        aave_std: &signer,
+        underlying_tokens_admin: &signer,
+        usre1: &signer
+    ) {
+        let user1_address = signer::address_of(usre1);
+        init_reserves(
+            aave_pool,
+            aave_role_super_admin,
+            aave_std,
+            underlying_tokens_admin
+        );
+
+        let underlying_u1_token_address =
+            mock_underlying_token_factory::token_address(utf8(b"U_1"));
+
+        let flashloan_receipt =
+            flashloan_logic::flash_loan_simple(
+                usre1,
+                user1_address,
+                underlying_u1_token_address,
+                0,
+                0
+            );
+
+        // ----> flashloan user repays flashloan + premium
+        flashloan_logic::pay_flash_loan_simple(usre1, flashloan_receipt);
+    }
 }

--- a/aave-core/tests/aave-logic/flashloan_validation_tests.move
+++ b/aave-core/tests/aave-logic/flashloan_validation_tests.move
@@ -898,4 +898,52 @@ module aave_pool::flashloan_validation_tests {
 
         flashloan_logic::pay_flash_loan_complex(usre1, flashloan_receipts);
     }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_role_super_admin = @aave_acl,
+            aave_std = @std,
+            underlying_tokens_admin = @aave_mock_underlyings,
+            usre1 = @0x41
+        )
+    ]
+    // validate_flashloan() with amount is zero (revert expected)
+    #[expected_failure(abort_code = 26, location = aave_pool::validation_logic)]
+    fun test_validate_flashloan_with_amount_is_zero(
+        aave_pool: &signer,
+        aave_role_super_admin: &signer,
+        aave_std: &signer,
+        underlying_tokens_admin: &signer,
+        usre1: &signer
+    ) {
+        let user1_address = signer::address_of(usre1);
+
+        init_reserves(
+            aave_pool,
+            aave_role_super_admin,
+            aave_std,
+            underlying_tokens_admin
+        );
+
+        let underlying_u1_token_address =
+            mock_underlying_token_factory::token_address(utf8(b"U_1"));
+
+        // user1 flashloan 1000 u_1 token from the pool
+        let assets = vector[underlying_u1_token_address];
+        let amounts = vector[0];
+        let interest_rate_modes = vector[2];
+        let flashloan_receipts =
+            flashloan_logic::flash_loan(
+                usre1,
+                user1_address,
+                assets,
+                amounts,
+                interest_rate_modes,
+                user1_address,
+                0
+            );
+
+        flashloan_logic::pay_flash_loan_complex(usre1, flashloan_receipts);
+    }
 }


### PR DESCRIPTION
This PR add input validation for flashloan:

1. Reject 0 amount
2. Restrict vector length to 128
3. Change loop to SimpleMap, improve runtime from O(n^2) to O(n)
4. Add test cases for 0 amount, empty vector, and out of bound vector length etc.