### PR TITLE
Prevent bypassing debt ceiling in isolation mode

### DIFF
--- a/aave-core/aave-math/sources/math_utils.move
+++ b/aave-core/aave-math/sources/math_utils.move
@@ -138,6 +138,21 @@ module aave_math::math_utils {
         result
     }
 
+    /// @notice Performs division with ceiling (rounding up)
+    /// @dev This function rounds up the result of division, ensuring that any remainder
+    ///      is accounted for by adding 1 to the quotient
+    /// @param numerator The numerator value
+    /// @param denominator The denominator value
+    /// @return The result of division rounded up
+    public fun ceil_div(numerator: u256, denominator: u256): u256 {
+        assert!(denominator > 0, error_config::get_edivision_by_zero());
+        if (numerator == 0) {
+            return 0
+        };
+        // Add denominator - 1 to numerator before division to achieve ceiling division
+        (numerator + denominator - 1) / denominator
+    }
+
     /// @dev Returns the seconds per year value
     /// @return Seconds per year constant
     public fun get_seconds_per_year(): u256 {

--- a/aave-core/aave-math/tests/math_utils_tests.move
+++ b/aave-core/aave-math/tests/math_utils_tests.move
@@ -9,6 +9,7 @@ module aave_math::math_utils_tests {
     use aave_math::math_utils::{
         calculate_compounded_interest_now,
         calculate_linear_interest,
+        ceil_div,
         get_half_percentage_factor_for_testing,
         get_percentage_factor,
         get_percentage_factor_for_testing,
@@ -229,5 +230,29 @@ module aave_math::math_utils_tests {
     #[expected_failure(abort_code = EOVERFLOW, location = aave_math::math_utils)]
     fun test_calculate_compounded_interest_with_current_time_less_than_last_update_timestamp() {
         calculate_compounded_interest(ray(), 1000000008, 1000000000);
+    }
+
+    #[test]
+    fun test_ceil_div() {
+        // Test basic cases
+        assert!(ceil_div(10, 3) == 4, TEST_SUCCESS); // 10/3 = 3.33... -> 4
+        assert!(ceil_div(10, 5) == 2, TEST_SUCCESS); // 10/5 = 2.0 -> 2
+        assert!(ceil_div(10, 7) == 2, TEST_SUCCESS); // 10/7 = 1.42... -> 2
+
+        // Test edge cases
+        assert!(ceil_div(0, 5) == 0, TEST_SUCCESS); // 0/5 = 0 -> 0
+        assert!(ceil_div(1, 1) == 1, TEST_SUCCESS); // 1/1 = 1 -> 1
+        assert!(ceil_div(1, 2) == 1, TEST_SUCCESS); // 1/2 = 0.5 -> 1
+
+        // Test large numbers
+        assert!(ceil_div(1000000, 999999) == 2, TEST_SUCCESS); // 1000000/999999 = 1.000001... -> 2
+        assert!(ceil_div(1000000, 1000000) == 1, TEST_SUCCESS); // 1000000/1000000 = 1.0 -> 1
+        assert!(ceil_div(1000000, 1000001) == 1, TEST_SUCCESS); // 1000000/1000001 = 0.999999... -> 1
+    }
+
+    #[test]
+    #[expected_failure(abort_code = EDIVISION_BY_ZERO, location = aave_math::math_utils)]
+    fun test_ceil_div_by_zero() {
+        ceil_div(10, 0);
     }
 }

--- a/aave-core/sources/aave-logic/borrow_logic.move
+++ b/aave-core/sources/aave-logic/borrow_logic.move
@@ -271,7 +271,7 @@ module aave_pool::borrow_logic {
 
             let next_isolation_mode_total_debt =
                 (isolation_mode_total_debt as u256)
-                    + (amount / math_utils::pow(10, decimals));
+                    + (math_utils::ceil_div(amount, math_utils::pow(10, decimals)));
             // Update isolation_mode_total_debt
             pool::set_reserve_isolation_mode_total_debt(
                 isolation_mode_collateral_reserve_data,

--- a/aave-core/sources/aave-logic/isolation_mode_logic.move
+++ b/aave-core/sources/aave-logic/isolation_mode_logic.move
@@ -60,7 +60,8 @@ module aave_pool::isolation_mode_logic {
             reserve_config::get_decimals(&reserve_config_map)
                 - reserve_config::get_debt_ceiling_decimals();
 
-        let isolated_debt_repaid = (repay_amount / math_utils::pow(10, debt_decimals));
+        let isolated_debt_repaid =
+            (math_utils::ceil_div(repay_amount, math_utils::pow(10, debt_decimals)));
 
         // since the debt ceiling does not take into account the interest accrued, it might happen that amount
         // repaid > debt in isolation mode

--- a/aave-core/sources/aave-logic/validation_logic.move
+++ b/aave-core/sources/aave-logic/validation_logic.move
@@ -286,14 +286,16 @@ module aave_pool::validation_logic {
             let total_debt =
                 isolation_mode_total_debt
                     + (
-                        amount
-                            / math_utils::pow(
+                        math_utils::ceil_div(
+                            amount,
+                            math_utils::pow(
                                 10,
                                 (
                                     reserve_decimals
                                         - reserve_config::get_debt_ceiling_decimals()
                                 )
                             )
+                        )
                     );
             assert!(
                 total_debt <= isolation_mode_debt_ceiling,

--- a/aave-core/tests/aave-logic/borrow_logic_tests.move
+++ b/aave-core/tests/aave-logic/borrow_logic_tests.move
@@ -477,224 +477,6 @@ module aave_pool::borrow_logic_tests {
         test(
             aave_pool = @aave_pool,
             aave_role_super_admin = @aave_acl,
-            aave_std = @std,
-            aave_oracle = @aave_oracle,
-            data_feeds = @data_feeds,
-            platform = @platform,
-            underlying_tokens_admin = @aave_mock_underlyings,
-            user1 = @0x41,
-            user2 = @0x42
-        )
-    ]
-    // User 1 supply 1000 U_1
-    // User 2 supplies U_2 and borrows U_1 in isolation, U_2 exits isolation.
-    // User 2 repay. U_2 enters isolation again
-    fun test_repay_with_isolation_mode(
-        aave_pool: &signer,
-        aave_role_super_admin: &signer,
-        aave_std: &signer,
-        aave_oracle: &signer,
-        data_feeds: &signer,
-        platform: &signer,
-        underlying_tokens_admin: &signer,
-        user1: &signer,
-        user2: &signer
-    ) {
-        let user1_address = signer::address_of(user1);
-        let user2_address = signer::address_of(user2);
-
-        init_reserves_with_oracle(
-            aave_pool,
-            aave_role_super_admin,
-            aave_std,
-            aave_oracle,
-            data_feeds,
-            platform,
-            underlying_tokens_admin,
-            aave_pool
-        );
-
-        let underlying_u1_token_address =
-            mock_underlying_token_factory::token_address(utf8(b"U_1"));
-        let underlying_u2_token_address =
-            mock_underlying_token_factory::token_address(utf8(b"U_2"));
-        // set borrowable in isolation for U_1
-        pool_configurator::set_borrowable_in_isolation(
-            aave_pool, underlying_u1_token_address, true
-        );
-
-        // set debt ceiling for U_2
-        pool_configurator::set_debt_ceiling(
-            aave_pool, underlying_u2_token_address, 10000
-        );
-
-        // mint 10000000 U_1 to user 1
-        let mint_u1_amount =
-            convert_to_currency_decimals(underlying_u1_token_address, 10000000);
-        mock_underlying_token_factory::mint(
-            underlying_tokens_admin,
-            user1_address,
-            (mint_u1_amount as u64),
-            underlying_u1_token_address
-        );
-
-        // set asset price for U_1
-        token_helper::set_asset_price(
-            aave_role_super_admin,
-            aave_oracle,
-            underlying_u1_token_address,
-            10
-        );
-
-        // supply 1000 U_1 to user 1
-        let supply_u1_amount =
-            convert_to_currency_decimals(underlying_u1_token_address, 1000);
-        aave_pool::supply_logic::supply(
-            user1,
-            underlying_u1_token_address,
-            supply_u1_amount,
-            user1_address,
-            0
-        );
-
-        // mint 10000000 U_2 to user 2
-        let mint_u2_amount =
-            convert_to_currency_decimals(underlying_u2_token_address, 10000000);
-        mock_underlying_token_factory::mint(
-            underlying_tokens_admin,
-            user2_address,
-            (mint_u2_amount as u64),
-            underlying_u2_token_address
-        );
-
-        // set asset price for U_2
-        token_helper::set_asset_price(
-            aave_role_super_admin,
-            aave_oracle,
-            underlying_u2_token_address,
-            10
-        );
-
-        // supply 2000 U_2 to user 2
-        let supply_u2_amount =
-            convert_to_currency_decimals(underlying_u2_token_address, 2000);
-        aave_pool::supply_logic::supply(
-            user2,
-            underlying_u2_token_address,
-            supply_u2_amount,
-            user2_address,
-            0
-        );
-
-        // Enables collateral
-        supply_logic::set_user_use_reserve_as_collateral(
-            user2, underlying_u2_token_address, true
-        );
-
-        let (_, _, _, _, usage_as_collateral_enabled) =
-            pool_data_provider::get_user_reserve_data(
-                underlying_u2_token_address, user2_address
-            );
-
-        assert!(usage_as_collateral_enabled == true, TEST_SUCCESS);
-
-        // set global time
-        timestamp::update_global_time_for_test_secs(1000);
-
-        // User 2 borrows U_1 against isolated U_2
-        let reserve_data = pool::get_reserve_data(underlying_u2_token_address);
-        let isolation_mode_total_debt_before_borrow =
-            pool::get_reserve_isolation_mode_total_debt(reserve_data);
-        let isolation_mode_total_debt_after_borrow =
-            isolation_mode_total_debt_before_borrow + 1000;
-
-        let first_borrow_u1_amount =
-            convert_to_currency_decimals(underlying_u1_token_address, 10);
-        borrow_logic::borrow(
-            user2,
-            underlying_u1_token_address,
-            first_borrow_u1_amount,
-            2,
-            0,
-            user2_address
-        );
-
-        // check isolation mode total debt emitted events
-        let emitted_events = emitted_events<IsolationModeTotalDebtUpdated>();
-        // make sure event of type was emitted
-        assert!(vector::length(&emitted_events) == 1, TEST_SUCCESS);
-
-        // check borrow event
-        let emitted_events = emitted_events<borrow_logic::Borrow>();
-        // make sure event of type was emitted
-        assert!(vector::length(&emitted_events) == 1, TEST_SUCCESS);
-
-        let reserve_data_after = pool::get_reserve_data(underlying_u2_token_address);
-        let isolation_mode_total_debt =
-            pool::get_reserve_isolation_mode_total_debt(reserve_data_after);
-        assert!(
-            isolation_mode_total_debt == isolation_mode_total_debt_after_borrow,
-            TEST_SUCCESS
-        );
-
-        // U_2 exits isolation mode (debt ceiling = 1000)
-        let new_debt_ceiling =
-            convert_to_currency_decimals(underlying_u1_token_address, 1000);
-        pool_configurator::set_debt_ceiling(
-            aave_pool,
-            underlying_u2_token_address,
-            new_debt_ceiling
-        );
-
-        let debt_ceiling =
-            pool_data_provider::get_debt_ceiling(underlying_u2_token_address);
-        assert!(debt_ceiling == new_debt_ceiling, TEST_SUCCESS);
-
-        // User 2 borrows 1 U_1
-        let second_borrow_u1_amount =
-            convert_to_currency_decimals(underlying_u1_token_address, 1);
-        borrow_logic::borrow(
-            user2,
-            underlying_u1_token_address,
-            second_borrow_u1_amount,
-            2,
-            0,
-            user2_address
-        );
-
-        // User 2 repays debt
-        mock_underlying_token_factory::mint(
-            underlying_tokens_admin,
-            user2_address,
-            (mint_u1_amount as u64),
-            underlying_u1_token_address
-        );
-
-        let repay_u1_amount =
-            convert_to_currency_decimals(underlying_u1_token_address, 10);
-        borrow_logic::repay(
-            user2,
-            underlying_u1_token_address,
-            repay_u1_amount,
-            2,
-            user2_address
-        );
-
-        let debt_ceiling =
-            pool_data_provider::get_debt_ceiling(underlying_u2_token_address);
-        assert!(debt_ceiling == new_debt_ceiling, TEST_SUCCESS);
-
-        let reserve_data = pool::get_reserve_data(underlying_u2_token_address);
-        let isolation_mode_total_debt =
-            pool::get_reserve_isolation_mode_total_debt(reserve_data);
-
-        assert!(isolation_mode_total_debt == 100, TEST_SUCCESS);
-    }
-
-    #[
-        test(
-            aave_pool = @aave_pool,
-            aave_role_super_admin = @aave_acl,
             aptos_std = @aptos_std,
             aave_oracle = @aave_oracle,
             data_feeds = @data_feeds,
@@ -1491,5 +1273,778 @@ module aave_pool::borrow_logic_tests {
             (current_variable_borrow_rate as u256) == cacl_current_variable_borrow_rate,
             TEST_SUCCESS
         );
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_role_super_admin = @aave_acl,
+            aptos_std = @aptos_std,
+            aave_oracle = @aave_oracle,
+            data_feeds = @data_feeds,
+            platform = @platform,
+            underlying_tokens_admin = @aave_mock_underlyings,
+            user1 = @0x041,
+            user2 = @0x042
+        )
+    ]
+    // @notice Tests that isolation mode debt ceiling uses ceiling division for accurate debt calculation
+    // @dev This test verifies that small borrow amounts are properly counted using ceiling division
+    //      and validates the total debt calculation matches the expected formula
+    fun test_isolation_mode_debt_ceiling_rounding_fix(
+        aave_pool: &signer,
+        aave_role_super_admin: &signer,
+        aptos_std: &signer,
+        aave_oracle: &signer,
+        data_feeds: &signer,
+        platform: &signer,
+        underlying_tokens_admin: &signer,
+        user1: &signer,
+        user2: &signer
+    ) {
+        init_reserves_with_oracle(
+            aave_pool,
+            aave_role_super_admin,
+            aptos_std,
+            aave_oracle,
+            data_feeds,
+            platform,
+            underlying_tokens_admin,
+            aave_pool
+        );
+
+        let user1_address = signer::address_of(user1);
+        let user2_address = signer::address_of(user2);
+        let underlying_u1_token_address =
+            mock_underlying_token_factory::token_address(utf8(b"U_1"));
+        let underlying_u2_token_address =
+            mock_underlying_token_factory::token_address(utf8(b"U_2"));
+
+        // Set U_2 in isolation mode with debt ceiling = 100 debt ceiling units
+        // This corresponds to 1 unit of borrowing in the debt ceiling calculation
+        let debt_ceiling = 100;
+        pool_configurator::set_debt_ceiling(
+            aave_pool,
+            underlying_u2_token_address,
+            debt_ceiling
+        );
+
+        // mint APT to user1 and user2
+        aptos_framework::aptos_coin_tests::mint_apt_fa_to_primary_fungible_store_for_test(
+            user1_address, 1_000_000_000
+        );
+        aptos_framework::aptos_coin_tests::mint_apt_fa_to_primary_fungible_store_for_test(
+            user2_address, 1_000_000_000
+        );
+
+        // mint 1000 U_1 for user 1 (liquidity provider)
+        let mint_u1_amount =
+            convert_to_currency_decimals(underlying_u1_token_address, 1000);
+        mock_underlying_token_factory::mint(
+            underlying_tokens_admin,
+            user1_address,
+            (mint_u1_amount as u64),
+            underlying_u1_token_address
+        );
+
+        // user 1 supplies 1000 U_1
+        supply_logic::supply(
+            user1,
+            underlying_u1_token_address,
+            mint_u1_amount,
+            user1_address,
+            0
+        );
+
+        // mint 1000 U_2 for user 2 (collateral for isolation mode)
+        let mint_u2_amount =
+            convert_to_currency_decimals(underlying_u2_token_address, 1000);
+        mock_underlying_token_factory::mint(
+            underlying_tokens_admin,
+            user2_address,
+            (mint_u2_amount as u64),
+            underlying_u2_token_address
+        );
+
+        // user 2 supplies 1000 U_2
+        supply_logic::supply(
+            user2,
+            underlying_u2_token_address,
+            mint_u2_amount,
+            user2_address,
+            0
+        );
+
+        // Enable U_2 as collateral for user 2
+        supply_logic::set_user_use_reserve_as_collateral(
+            user2, underlying_u2_token_address, true
+        );
+
+        // set asset prices
+        token_helper::set_asset_price(
+            aave_role_super_admin,
+            aave_oracle,
+            underlying_u1_token_address,
+            100
+        );
+
+        token_helper::set_asset_price(
+            aave_role_super_admin,
+            aave_oracle,
+            underlying_u2_token_address,
+            100
+        );
+
+        // set global time
+        timestamp::update_global_time_for_test_secs(1000);
+
+        // set U_1 as borrowable in isolation
+        pool_configurator::set_borrowable_in_isolation(
+            aave_pool, underlying_u1_token_address, true
+        );
+
+        // First borrow: 0.5 units
+        let first_small_borrow_amount =
+            convert_to_currency_decimals(underlying_u1_token_address, 1) / 2;
+        borrow_logic::borrow(
+            user2,
+            underlying_u1_token_address,
+            first_small_borrow_amount,
+            2,
+            0,
+            user2_address
+        );
+
+        // Verify first borrow debt calculation
+        let reserve_data = pool::get_reserve_data(underlying_u2_token_address);
+        let isolation_mode_total_debt =
+            pool::get_reserve_isolation_mode_total_debt(reserve_data);
+        assert!(isolation_mode_total_debt == 50, TEST_SUCCESS);
+
+        // Second borrow: 0.33 units
+        let second_small_borrow_amount =
+            convert_to_currency_decimals(underlying_u1_token_address, 1) / 3;
+        borrow_logic::borrow(
+            user2,
+            underlying_u1_token_address,
+            second_small_borrow_amount,
+            2,
+            0,
+            user2_address
+        );
+
+        // Verify total debt calculation matches expected formula
+        let reserve_data = pool::get_reserve_data(underlying_u2_token_address);
+        let isolation_mode_total_debt =
+            pool::get_reserve_isolation_mode_total_debt(reserve_data);
+
+        // Calculate expected total debt using ceiling division formula
+        let u1_decimals =
+            (fungible_asset_manager::decimals(underlying_u1_token_address) as u256);
+        let difference_decimals = u1_decimals
+            - reserve_config::get_debt_ceiling_decimals();
+        let real_decimals = math_utils::pow(10, difference_decimals);
+        let expected_total_debt =
+            math_utils::ceil_div(first_small_borrow_amount, real_decimals)
+                + math_utils::ceil_div(second_small_borrow_amount, real_decimals);
+
+        assert!((isolation_mode_total_debt as u256) == expected_total_debt, TEST_SUCCESS)
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_role_super_admin = @aave_acl,
+            aptos_std = @aptos_std,
+            aave_oracle = @aave_oracle,
+            data_feeds = @data_feeds,
+            platform = @platform,
+            underlying_tokens_admin = @aave_mock_underlyings,
+            user1 = @0x041,
+            user2 = @0x042
+        )
+    ]
+    // @notice Tests that isolation mode debt ceiling properly rejects borrows when ceiling is exceeded
+    // @dev This test verifies that ceiling division correctly calculates debt and rejects when limit is reached
+    #[expected_failure(abort_code = 53, location = aave_pool::validation_logic)]
+    fun test_isolation_mode_debt_ceiling_rejection(
+        aave_pool: &signer,
+        aave_role_super_admin: &signer,
+        aptos_std: &signer,
+        aave_oracle: &signer,
+        data_feeds: &signer,
+        platform: &signer,
+        underlying_tokens_admin: &signer,
+        user1: &signer,
+        user2: &signer
+    ) {
+        init_reserves_with_oracle(
+            aave_pool,
+            aave_role_super_admin,
+            aptos_std,
+            aave_oracle,
+            data_feeds,
+            platform,
+            underlying_tokens_admin,
+            aave_pool
+        );
+
+        let user1_address = signer::address_of(user1);
+        let user2_address = signer::address_of(user2);
+        let underlying_u1_token_address =
+            mock_underlying_token_factory::token_address(utf8(b"U_1"));
+        let underlying_u2_token_address =
+            mock_underlying_token_factory::token_address(utf8(b"U_2"));
+
+        // Set U_2 in isolation mode with debt ceiling = 100 debt ceiling units
+        // This corresponds to 1 unit of borrowing in the debt ceiling calculation
+        let debt_ceiling = 100;
+        pool_configurator::set_debt_ceiling(
+            aave_pool,
+            underlying_u2_token_address,
+            debt_ceiling
+        );
+
+        // mint APT to user1 and user2
+        aptos_framework::aptos_coin_tests::mint_apt_fa_to_primary_fungible_store_for_test(
+            user1_address, 1_000_000_000
+        );
+        aptos_framework::aptos_coin_tests::mint_apt_fa_to_primary_fungible_store_for_test(
+            user2_address, 1_000_000_000
+        );
+
+        // mint 1000 U_1 for user 1 (liquidity provider)
+        let mint_u1_amount =
+            convert_to_currency_decimals(underlying_u1_token_address, 1000);
+        mock_underlying_token_factory::mint(
+            underlying_tokens_admin,
+            user1_address,
+            (mint_u1_amount as u64),
+            underlying_u1_token_address
+        );
+
+        // user 1 supplies 1000 U_1
+        supply_logic::supply(
+            user1,
+            underlying_u1_token_address,
+            mint_u1_amount,
+            user1_address,
+            0
+        );
+
+        // mint 1000 U_2 for user 2 (collateral for isolation mode)
+        let mint_u2_amount =
+            convert_to_currency_decimals(underlying_u2_token_address, 1000);
+        mock_underlying_token_factory::mint(
+            underlying_tokens_admin,
+            user2_address,
+            (mint_u2_amount as u64),
+            underlying_u2_token_address
+        );
+
+        // user 2 supplies 1000 U_2
+        supply_logic::supply(
+            user2,
+            underlying_u2_token_address,
+            mint_u2_amount,
+            user2_address,
+            0
+        );
+
+        // Enable U_2 as collateral for user 2
+        supply_logic::set_user_use_reserve_as_collateral(
+            user2, underlying_u2_token_address, true
+        );
+
+        // set asset prices
+        token_helper::set_asset_price(
+            aave_role_super_admin,
+            aave_oracle,
+            underlying_u1_token_address,
+            100
+        );
+        token_helper::set_asset_price(
+            aave_role_super_admin,
+            aave_oracle,
+            underlying_u2_token_address,
+            100
+        );
+
+        // set global time
+        timestamp::update_global_time_for_test_secs(1000);
+
+        // set U_1 as borrowable in isolation
+        pool_configurator::set_borrowable_in_isolation(
+            aave_pool, underlying_u1_token_address, true
+        );
+
+        // First borrow: 0.4 units (40 debt ceiling units)
+        let first_borrow_amount =
+            convert_to_currency_decimals(underlying_u1_token_address, 1) * 4 / 10;
+        borrow_logic::borrow(
+            user2,
+            underlying_u1_token_address,
+            first_borrow_amount,
+            2,
+            0,
+            user2_address
+        );
+
+        // Verify first borrow debt calculation
+        let reserve_data = pool::get_reserve_data(underlying_u2_token_address);
+        let isolation_mode_total_debt =
+            pool::get_reserve_isolation_mode_total_debt(reserve_data);
+        assert!(isolation_mode_total_debt == 40, TEST_SUCCESS);
+
+        // Second borrow: 0.4 units (40 debt ceiling units)
+        let second_borrow_amount =
+            convert_to_currency_decimals(underlying_u1_token_address, 1) * 4 / 10;
+        borrow_logic::borrow(
+            user2,
+            underlying_u1_token_address,
+            second_borrow_amount,
+            2,
+            0,
+            user2_address
+        );
+
+        // Verify second borrow debt calculation
+        let reserve_data = pool::get_reserve_data(underlying_u2_token_address);
+        let isolation_mode_total_debt =
+            pool::get_reserve_isolation_mode_total_debt(reserve_data);
+        assert!(isolation_mode_total_debt == 80, TEST_SUCCESS);
+
+        // Third borrow: 0.3 units (30 debt ceiling units) - should fail because 40 + 40 + 30 = 110 > 100
+        let third_borrow_amount =
+            convert_to_currency_decimals(underlying_u1_token_address, 1) * 3 / 10;
+        borrow_logic::borrow(
+            user2,
+            underlying_u1_token_address,
+            third_borrow_amount,
+            2,
+            0,
+            user2_address
+        );
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_role_super_admin = @aave_acl,
+            aptos_std = @aptos_std,
+            aave_oracle = @aave_oracle,
+            data_feeds = @data_feeds,
+            platform = @platform,
+            underlying_tokens_admin = @aave_mock_underlyings,
+            user1 = @0x041,
+            user2 = @0x042
+        )
+    ]
+    // @notice Tests that isolation mode debt ceiling uses consistent ceiling division for both borrow and repay
+    // @dev This test verifies that small amounts are handled consistently to prevent debt ceiling bypass
+    //      while maintaining predictable behavior for users
+    fun test_isolation_mode_debt_ceiling_consistency(
+        aave_pool: &signer,
+        aave_role_super_admin: &signer,
+        aptos_std: &signer,
+        aave_oracle: &signer,
+        data_feeds: &signer,
+        platform: &signer,
+        underlying_tokens_admin: &signer,
+        user1: &signer,
+        user2: &signer
+    ) {
+        init_reserves_with_oracle(
+            aave_pool,
+            aave_role_super_admin,
+            aptos_std,
+            aave_oracle,
+            data_feeds,
+            platform,
+            underlying_tokens_admin,
+            aave_pool
+        );
+
+        let user1_address = signer::address_of(user1);
+        let user2_address = signer::address_of(user2);
+        let underlying_u1_token_address =
+            mock_underlying_token_factory::token_address(utf8(b"U_1"));
+        let underlying_u2_token_address =
+            mock_underlying_token_factory::token_address(utf8(b"U_2"));
+
+        // Set U_2 in isolation mode with debt ceiling = 100 debt ceiling units
+        let debt_ceiling = 100;
+        pool_configurator::set_debt_ceiling(
+            aave_pool,
+            underlying_u2_token_address,
+            debt_ceiling
+        );
+
+        // mint APT to user1 and user2
+        aptos_framework::aptos_coin_tests::mint_apt_fa_to_primary_fungible_store_for_test(
+            user1_address, 1_000_000_000
+        );
+        aptos_framework::aptos_coin_tests::mint_apt_fa_to_primary_fungible_store_for_test(
+            user2_address, 1_000_000_000
+        );
+
+        // mint 1000 U_1 for user 1 (liquidity provider)
+        let mint_u1_amount =
+            convert_to_currency_decimals(underlying_u1_token_address, 1000);
+        mock_underlying_token_factory::mint(
+            underlying_tokens_admin,
+            user1_address,
+            (mint_u1_amount as u64),
+            underlying_u1_token_address
+        );
+
+        // user 1 supplies 1000 U_1
+        supply_logic::supply(
+            user1,
+            underlying_u1_token_address,
+            mint_u1_amount,
+            user1_address,
+            0
+        );
+
+        // mint 1000 U_2 for user 2 (collateral for isolation mode)
+        let mint_u2_amount =
+            convert_to_currency_decimals(underlying_u2_token_address, 1000);
+        mock_underlying_token_factory::mint(
+            underlying_tokens_admin,
+            user2_address,
+            (mint_u2_amount as u64),
+            underlying_u2_token_address
+        );
+
+        // user 2 supplies 1000 U_2
+        supply_logic::supply(
+            user2,
+            underlying_u2_token_address,
+            mint_u2_amount,
+            user2_address,
+            0
+        );
+
+        // Enable U_2 as collateral for user 2
+        supply_logic::set_user_use_reserve_as_collateral(
+            user2, underlying_u2_token_address, true
+        );
+
+        // set asset prices
+        token_helper::set_asset_price(
+            aave_role_super_admin,
+            aave_oracle,
+            underlying_u1_token_address,
+            100
+        );
+
+        token_helper::set_asset_price(
+            aave_role_super_admin,
+            aave_oracle,
+            underlying_u2_token_address,
+            100
+        );
+
+        // set global time
+        timestamp::update_global_time_for_test_secs(1000);
+
+        // set U_1 as borrowable in isolation
+        pool_configurator::set_borrowable_in_isolation(
+            aave_pool, underlying_u1_token_address, true
+        );
+
+        // Test 1: Small borrow amount (0.33 units) - should increment debt by 1 unit
+        let small_borrow_amount =
+            convert_to_currency_decimals(underlying_u1_token_address, 1) / 3;
+        borrow_logic::borrow(
+            user2,
+            underlying_u1_token_address,
+            small_borrow_amount,
+            2,
+            0,
+            user2_address
+        );
+
+        // Verify debt calculation
+        let reserve_data = pool::get_reserve_data(underlying_u2_token_address);
+        let isolation_mode_total_debt =
+            pool::get_reserve_isolation_mode_total_debt(reserve_data);
+        assert!(isolation_mode_total_debt == 34, TEST_SUCCESS);
+
+        // Mint U_1 to user2 for repayment
+        mock_underlying_token_factory::mint(
+            underlying_tokens_admin,
+            user2_address,
+            (small_borrow_amount as u64),
+            underlying_u1_token_address
+        );
+
+        // Test 2: Repay the same small amount - should decrement debt by 1 unit
+        borrow_logic::repay(
+            user2,
+            underlying_u1_token_address,
+            small_borrow_amount,
+            2,
+            user2_address
+        );
+
+        // Verify debt is back to zero (consistent rounding)
+        let reserve_data = pool::get_reserve_data(underlying_u2_token_address);
+        let isolation_mode_total_debt =
+            pool::get_reserve_isolation_mode_total_debt(reserve_data);
+        assert!(isolation_mode_total_debt == 0, TEST_SUCCESS);
+
+        // Test 3: Multiple small operations to verify consistency
+        let tiny_amount = convert_to_currency_decimals(underlying_u1_token_address, 1)
+            / 10; // 0.1 units
+
+        // Borrow 10 times 0.1 units
+        let i = 0;
+        while (i < 10) {
+            borrow_logic::borrow(
+                user2,
+                underlying_u1_token_address,
+                tiny_amount,
+                2,
+                0,
+                user2_address
+            );
+            i = i + 1;
+        };
+
+        // Verify total debt (10 * 0.1 = 1 unit, but each 0.1 rounds up to 1 debt unit)
+        let reserve_data = pool::get_reserve_data(underlying_u2_token_address);
+        let isolation_mode_total_debt =
+            pool::get_reserve_isolation_mode_total_debt(reserve_data);
+        assert!(isolation_mode_total_debt == 100, TEST_SUCCESS); // 10 * 10 = 100 debt units
+
+        // Mint enough U_1 for repayment
+        mock_underlying_token_factory::mint(
+            underlying_tokens_admin,
+            user2_address,
+            (tiny_amount * 10 as u64),
+            underlying_u1_token_address
+        );
+
+        // Repay 10 times 0.1 units
+        let i = 0;
+        while (i < 10) {
+            borrow_logic::repay(
+                user2,
+                underlying_u1_token_address,
+                tiny_amount,
+                2,
+                user2_address
+            );
+            i = i + 1;
+        };
+
+        // Verify debt is back to zero (consistent rounding)
+        let reserve_data = pool::get_reserve_data(underlying_u2_token_address);
+        let isolation_mode_total_debt =
+            pool::get_reserve_isolation_mode_total_debt(reserve_data);
+        assert!(isolation_mode_total_debt == 0, TEST_SUCCESS);
+    }
+
+    #[
+        test(
+            aave_pool = @aave_pool,
+            aave_role_super_admin = @aave_acl,
+            aptos_std = @aptos_std,
+            aave_oracle = @aave_oracle,
+            data_feeds = @data_feeds,
+            platform = @platform,
+            underlying_tokens_admin = @aave_mock_underlyings,
+            user1 = @0x041,
+            user2 = @0x042
+        )
+    ]
+    // @notice Tests that isolation mode debt ceiling uses ceiling division for accurate debt calculation during repayment
+    // @dev This test verifies that small repay amounts are properly counted using ceiling division
+    //      and validates the total debt reduction matches the expected formula
+    fun test_isolation_mode_debt_ceiling_repayment_rounding_fix(
+        aave_pool: &signer,
+        aave_role_super_admin: &signer,
+        aptos_std: &signer,
+        aave_oracle: &signer,
+        data_feeds: &signer,
+        platform: &signer,
+        underlying_tokens_admin: &signer,
+        user1: &signer,
+        user2: &signer
+    ) {
+        init_reserves_with_oracle(
+            aave_pool,
+            aave_role_super_admin,
+            aptos_std,
+            aave_oracle,
+            data_feeds,
+            platform,
+            underlying_tokens_admin,
+            aave_pool
+        );
+
+        let user1_address = signer::address_of(user1);
+        let user2_address = signer::address_of(user2);
+        let underlying_u1_token_address =
+            mock_underlying_token_factory::token_address(utf8(b"U_1"));
+        let underlying_u2_token_address =
+            mock_underlying_token_factory::token_address(utf8(b"U_2"));
+
+        // Set U_2 in isolation mode with debt ceiling = 100 debt ceiling units
+        let debt_ceiling = 100;
+        pool_configurator::set_debt_ceiling(
+            aave_pool,
+            underlying_u2_token_address,
+            debt_ceiling
+        );
+
+        // mint APT to user1 and user2
+        aptos_framework::aptos_coin_tests::mint_apt_fa_to_primary_fungible_store_for_test(
+            user1_address, 1_000_000_000
+        );
+        aptos_framework::aptos_coin_tests::mint_apt_fa_to_primary_fungible_store_for_test(
+            user2_address, 1_000_000_000
+        );
+
+        // mint 1000 U_1 for user 1 (liquidity provider)
+        let mint_u1_amount =
+            convert_to_currency_decimals(underlying_u1_token_address, 1000);
+        mock_underlying_token_factory::mint(
+            underlying_tokens_admin,
+            user1_address,
+            (mint_u1_amount as u64),
+            underlying_u1_token_address
+        );
+
+        // user 1 supplies 1000 U_1
+        supply_logic::supply(
+            user1,
+            underlying_u1_token_address,
+            mint_u1_amount,
+            user1_address,
+            0
+        );
+
+        // mint 1000 U_2 for user 2 (collateral for isolation mode)
+        let mint_u2_amount =
+            convert_to_currency_decimals(underlying_u2_token_address, 1000);
+        mock_underlying_token_factory::mint(
+            underlying_tokens_admin,
+            user2_address,
+            (mint_u2_amount as u64),
+            underlying_u2_token_address
+        );
+
+        // user 2 supplies 1000 U_2
+        supply_logic::supply(
+            user2,
+            underlying_u2_token_address,
+            mint_u2_amount,
+            user2_address,
+            0
+        );
+
+        // Enable U_2 as collateral for user 2
+        supply_logic::set_user_use_reserve_as_collateral(
+            user2, underlying_u2_token_address, true
+        );
+
+        // set asset prices
+        token_helper::set_asset_price(
+            aave_role_super_admin,
+            aave_oracle,
+            underlying_u1_token_address,
+            100
+        );
+
+        token_helper::set_asset_price(
+            aave_role_super_admin,
+            aave_oracle,
+            underlying_u2_token_address,
+            100
+        );
+
+        // set global time
+        timestamp::update_global_time_for_test_secs(1000);
+
+        // set U_1 as borrowable in isolation
+        pool_configurator::set_borrowable_in_isolation(
+            aave_pool, underlying_u1_token_address, true
+        );
+
+        // Borrow 1 unit to establish isolation mode debt
+        let borrow_amount = convert_to_currency_decimals(underlying_u1_token_address, 1);
+        borrow_logic::borrow(
+            user2,
+            underlying_u1_token_address,
+            borrow_amount,
+            2,
+            0,
+            user2_address
+        );
+
+        // Verify initial debt calculation
+        let reserve_data = pool::get_reserve_data(underlying_u2_token_address);
+        let isolation_mode_total_debt =
+            pool::get_reserve_isolation_mode_total_debt(reserve_data);
+        assert!(isolation_mode_total_debt == 100, TEST_SUCCESS);
+
+        // Mint U_1 to user2 for repayment
+        mock_underlying_token_factory::mint(
+            underlying_tokens_admin,
+            user2_address,
+            (borrow_amount as u64),
+            underlying_u1_token_address
+        );
+
+        // Repay 0.5 units (should reduce debt by 50 units using ceiling division)
+        let repay_amount = convert_to_currency_decimals(underlying_u1_token_address, 1)
+            / 2;
+        borrow_logic::repay(
+            user2,
+            underlying_u1_token_address,
+            repay_amount,
+            2,
+            user2_address
+        );
+
+        // Verify debt reduction using ceiling division
+        let reserve_data = pool::get_reserve_data(underlying_u2_token_address);
+        let isolation_mode_total_debt =
+            pool::get_reserve_isolation_mode_total_debt(reserve_data);
+        assert!(isolation_mode_total_debt == 50, TEST_SUCCESS);
+
+        // Repay another 0.33 units (should reduce debt by 33 units using ceiling division)
+        let second_repay_amount =
+            convert_to_currency_decimals(underlying_u1_token_address, 1) / 3;
+        borrow_logic::repay(
+            user2,
+            underlying_u1_token_address,
+            second_repay_amount,
+            2,
+            user2_address
+        );
+
+        // Verify final debt calculation matches expected formula
+        let reserve_data = pool::get_reserve_data(underlying_u2_token_address);
+        let isolation_mode_total_debt =
+            pool::get_reserve_isolation_mode_total_debt(reserve_data);
+
+        // Calculate expected remaining debt using ceiling division formula
+        let u1_decimals =
+            (fungible_asset_manager::decimals(underlying_u1_token_address) as u256);
+        let difference_decimals = u1_decimals
+            - reserve_config::get_debt_ceiling_decimals();
+        let real_decimals = math_utils::pow(10, difference_decimals);
+        let expected_debt_reduction =
+            math_utils::ceil_div(repay_amount, real_decimals)
+                + math_utils::ceil_div(second_repay_amount, real_decimals);
+        let expected_remaining_debt = 100 - expected_debt_reduction;
+
+        assert!(
+            (isolation_mode_total_debt as u256) == expected_remaining_debt, TEST_SUCCESS
+        )
     }
 }


### PR DESCRIPTION
The issue:

The current debt_ceiling will truncate (asset_decimal - 2) digit when incrementing, it means if the borrow asset is 6 decimals, debt_ceiling will only increment to the precision of 1 cent (10^4).

A user who micro borrows slightly than 1 cent (9,999 unir) each time, for as many times as possible, will bypass the debt ceiling each and every time, which break the protocol integrity.

```
//validation_logic.move
let isolation_mode_total_debt =
    pool::get_reserve_isolation_mode_total_debt(mode_collateral_reserve_data) as u256;
let total_debt =
    isolation_mode_total_debt
      + (amount
         / math_utils::pow(
             10,
             (reserve_decimals
                - reserve_config::get_debt_ceiling_decimals())
         )
        );
assert!( total_debt <= isolation_mode_debt_ceiling, … );

```
The fix:

Add ceil_div() in math library
Use ceil_div() to replace simple division in borrow logic, isolation mode, validation logic etc.
Add more test cases

