### PR TITLE
fix(collector): change withdraw function to entry function

### DIFF
--- a/aave-core/sources/aave-periphery/collector.move
+++ b/aave-core/sources/aave-periphery/collector.move
@@ -95,7 +95,7 @@ module aave_pool::collector {
     /// @param asset The address of the asset to withdraw
     /// @param receiver The address that will receive the withdrawn assets
     /// @param amount The amount to withdraw
-    public fun withdraw(
+    public entry fun withdraw(
         sender: &signer,
         asset: address,
         receiver: address,


### PR DESCRIPTION
- Change withdraw function from public fun to public entry fun
- Allows funds admin to directly call the function via wallet/CLI
- Maintains existing permission checks and functionality
- Addresses security concern about admin accessibility