### PR TITLE
fix(transfer_strategy): change emergency withdrawal to entry function

### DIFF
--- a/aave-core/sources/aave-periphery/transfer_strategy.move
+++ b/aave-core/sources/aave-periphery/transfer_strategy.move
@@ -124,7 +124,7 @@ module aave_pool::transfer_strategy {
     /// @param to The address to which tokens are transferred
     /// @param amount The amount of tokens to transfer
     /// @param strategy The pull rewards transfer strategy object
-    public fun pull_rewards_transfer_strategy_emergency_withdrawal(
+    public entry fun pull_rewards_transfer_strategy_emergency_withdrawal(
         caller: &signer,
         token: address,
         to: address,


### PR DESCRIPTION
- Change pull_rewards_transfer_strategy_emergency_withdrawal from public fun to public entry fun
- Allows admin accounts to directly call emergency withdrawal via wallet/CLI
- Maintains existing permission checks (only rewards admin can call)
