### PR TITLE
fix: assert custom asset price is less than the price cap

### DIFF
--- a/aave-core/aave-config/sources/error_config.move
+++ b/aave-core/aave-config/sources/error_config.move
@@ -255,6 +255,8 @@ module aave_config::error_config {
     const EINVALID_SNAPSHOT_RATIO: u64 = 1227;
     /// The snapshot timestamp is invalid
     const EINVALID_SNAPSHOT_TIMESTAMP: u64 = 1228;
+    /// The assigned custom price is above the price cap
+    const ECUSTOM_PRICE_ABOVE_PRICE_CAP: u64 = 1229;
 
     // aave_rate module error code range from 1301 to 1400.
     /// @notice Account is not the rate's owner
@@ -857,6 +859,12 @@ module aave_config::error_config {
     /// @return Error code as u64
     public fun get_einvalid_snapshot_timestamp(): u64 {
         EINVALID_SNAPSHOT_TIMESTAMP
+    }
+
+    /// @notice Returns the error code for custom price above price cap
+    /// @return Error code as u64
+    public fun get_ecustom_price_above_price_cap(): u64 {
+        ECUSTOM_PRICE_ABOVE_PRICE_CAP
     }
 
     /// @notice Returns the error code for invalid optimal usage ratio

--- a/aave-core/aave-config/tests/error_tests.move
+++ b/aave-core/aave-config/tests/error_tests.move
@@ -169,7 +169,8 @@ module aave_config::error_tests {
         get_einvalid_growth_rate,
         get_einvalid_snapshot_delay,
         get_einvalid_snapshot_ratio,
-        get_einvalid_snapshot_timestamp
+        get_einvalid_snapshot_timestamp,
+        get_ecustom_price_above_price_cap
     };
 
     const TEST_SUCCESS: u64 = 1;
@@ -438,6 +439,8 @@ module aave_config::error_tests {
     const EINVALID_SNAPSHOT_RATIO: u64 = 1227;
     /// The snapshot timestamp is invalid
     const EINVALID_SNAPSHOT_TIMESTAMP: u64 = 1228;
+    /// The assigned custom price is above the price cap
+    const ECUSTOM_PRICE_ABOVE_PRICE_CAP: u64 = 1229;
 
     // aave_rate module error code range from 1301 to 1400.
 
@@ -1310,6 +1313,14 @@ module aave_config::error_tests {
     public fun test_get_einvalid_snapshot_timestamp() {
         assert!(
             get_einvalid_snapshot_timestamp() == EINVALID_SNAPSHOT_TIMESTAMP,
+            TEST_SUCCESS
+        );
+    }
+
+    #[test]
+    public fun test_ecustom_price_above_price_cap() {
+        assert!(
+            get_ecustom_price_above_price_cap() == ECUSTOM_PRICE_ABOVE_PRICE_CAP,
             TEST_SUCCESS
         );
     }

--- a/aave-core/aave-oracle/sources/oracle.move
+++ b/aave-core/aave-oracle/sources/oracle.move
@@ -559,6 +559,13 @@ module aave_oracle::oracle {
     ) acquires PriceOracleData {
         only_asset_listing_or_pool_admin(account);
         assert!(custom_price > 0, error_config::get_ezero_asset_custom_price());
+        if (is_asset_price_capped(asset)) {
+            let (capped_price, _) = get_asset_price_and_timestamp(asset);
+            assert!(
+                custom_price <= capped_price,
+                error_config::get_ecustom_price_above_price_cap()
+            );
+        };
         update_asset_custom_price(asset, custom_price);
     }
 


### PR DESCRIPTION
The oracle module allows either the asset listing admin or the pool admin to set a custom price for certain assets. However, the set_asset_custom_price function does not verify whether a price cap is defined for the asset. As a result, if a custom price is set above the cap, the oracle will still return the capped price rather than the custom price. This discrepancy can lead to unintended consequences, as the effective price used by the system will differ from the custom price that was set. The PR corrects this behaviour.