### PR TITLE
chore: add Dependency Review GitHub Action

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,4 +1,5 @@
 name: Dependency Review
+
 on:
   - pull_request
 


### PR DESCRIPTION
The dependency review action scans your pull requests for dependency changes and raises an error if any new dependencies have known vulnerabilities. Once installed, if the workflow run is marked as required, pull requests introducing known vulnerable packages will be blocked from merging.